### PR TITLE
[Feature] Sort cards

### DIFF
--- a/pages/deck/_deckId.vue
+++ b/pages/deck/_deckId.vue
@@ -6,7 +6,7 @@
       </div>
       <fe-grid v-if="hasCards" :class="$s.Grid">
         <fe-grid-item
-          v-for="(card, i) in cards"
+          v-for="(card, i) in sortedCards"
           :key="i"
           span="fullwidth"
           tablet-span="one-half"
@@ -44,12 +44,43 @@ export default {
   computed: {
     ...mapState("cards", ["cardRank", "suitRank", "rotationCard", "deck"]),
 
-    cards() {
-      return this.deck && this.deck.cards;
+    hasCards() {
+      return this.deck && this.deck.cards && this.deck.cards.length;
     },
 
-    hasCards() {
-      return this.cards && this.cards.length;
+    sortedCards() {
+      if (!this.hasCards) {
+        return;
+      } else {
+        const cards = this.deck.cards.slice();
+        return cards.sort(this.compareCards);
+      }
+    },
+  },
+
+  methods: {
+    compareCards(a, b) {
+      const cardOne = this.cardRank.indexOf(this.getCardVale(a.code));
+      const cardTwo = this.cardRank.indexOf(this.getCardVale(b.code));
+      const suitOne = this.suitRank.indexOf(this.getSuitValue(a.code));
+      const suitTwo = this.suitRank.indexOf(this.getSuitValue(b.code));
+
+      if (cardOne > cardTwo) return 1;
+      if (cardOne < cardTwo) return -1;
+
+      if (cardOne === cardTwo) {
+        if (suitOne > suitTwo) return 1;
+        if (suitOne < suitTwo) return -1;
+      }
+
+      return 0;
+    },
+
+    getCardVale(cardCode) {
+      return cardCode.substr(0, cardCode.length - 1);
+    },
+    getSuitValue(cardCode) {
+      return cardCode.charAt(cardCode.length - 1);
     },
   },
 

--- a/pages/deck/_deckId.vue
+++ b/pages/deck/_deckId.vue
@@ -21,6 +21,8 @@
       <strong>Rotation Card:</strong> {{ rotationCard }}
     </h2>
 
+    <h2 :class="$s.DataTitle"><strong>High Card:</strong> {{ highCard }}</h2>
+
     <fe-button to="/deck/new">
       Start Over
     </fe-button>
@@ -48,6 +50,12 @@ export default {
       return this.deck && this.deck.cards && this.deck.cards.length;
     },
 
+    highCard() {
+      return this.hasCards
+        ? `${this.sortedCards[0].value} of ${this.sortedCards[0].suit}`
+        : null;
+    },
+
     sortedCards() {
       if (!this.hasCards) {
         return;
@@ -65,9 +73,11 @@ export default {
       const suitOne = this.suitRank.indexOf(this.getSuitValue(a.code));
       const suitTwo = this.suitRank.indexOf(this.getSuitValue(b.code));
 
+      // Organize first by card
       if (cardOne > cardTwo) return 1;
       if (cardOne < cardTwo) return -1;
 
+      // If the cards are the same, check suit
       if (cardOne === cardTwo) {
         if (suitOne > suitTwo) return 1;
         if (suitOne < suitTwo) return -1;
@@ -79,6 +89,7 @@ export default {
     getCardVale(cardCode) {
       return cardCode.substr(0, cardCode.length - 1);
     },
+
     getSuitValue(cardCode) {
       return cardCode.charAt(cardCode.length - 1);
     },

--- a/pages/deck/new.vue
+++ b/pages/deck/new.vue
@@ -139,7 +139,7 @@ export default {
     async handleSubmit() {
       const filteredCards = this.chosenCards.filter(Boolean).join(",");
 
-      if (!filteredCards.length) {
+      if (!filteredCards) {
         this.error = "Please select a card.";
       } else {
         this.isLoading = true;


### PR DESCRIPTION
### Problem
Cards are displayed in the ordered entered, not ranked based on the rotation card and the rotated cardRank and suitRank arrays.

**Task:** https://github.com/JacobRex/front-end-challenge/projects/1#card-36965301

### Description
- Adds a compareCards function to organize a list of cards based on the index of their card and suit value. First, card values are checked by looking at the index of each card in the cardRank array. If the cards are different, we sort accordingly. If theyre the same, we do the same check for suit.
- Adds a sortedCards computed prop and renders the cards based on this
- Prints the high card on the page

---

![image](https://user-images.githubusercontent.com/11563996/80242722-6a199a80-862b-11ea-83f6-596381a826aa.png)

